### PR TITLE
Use proper specific type for 'id'

### DIFF
--- a/bot/migrations/20200925231517_create_among_us_session_table.js
+++ b/bot/migrations/20200925231517_create_among_us_session_table.js
@@ -1,6 +1,6 @@
 exports.up = knex =>
     knex.schema.createTable("among_us_session", table => {
-        table.increments("id").primary();
+        table.specificType("id", "integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY");
         table.specificType("guild", "text").notNullable();
         table.specificType("channel", "text").notNullable();
         table.specificType("message", "text").notNullable();


### PR DESCRIPTION
IDENTITY is supposed to be used since its introduction in Postgres 10 anyways..
Also the bot never generates the ID itself, so let Postgres just do it always.
Fixes the weird `NotNullConstraintViolationException` people have.